### PR TITLE
Add support for ui-less safari pwa

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta name="description" content="The congratulations we rightly deserve" />
     <meta name="theme-color" content="#2a3340" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="shortcut icon" href="/static/favicon.png" />
     <link rel="apple-touch-icon" href="/static/party-icon-apple-touch.png" />


### PR DESCRIPTION
They don't actually implement the pwa spec at all, so they need their
own special tag