### PR TITLE
Work around iOS-specific font doubling issue

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,10 +1,9 @@
-@import url("https://fonts.googleapis.com/css?family=Varela+Round");
-
 body {
   background: #2a3340;
   border: 0;
   margin: 0;
-  font-family: "Varela Round", sans-serif;
+  font-family: -apple-system-headline, -apple-system, "Helvetica Neue",
+    "Helvetica", "Roboto", sans-serif;
 }
 
 #container {


### PR DESCRIPTION
This seems to be an iOS-only bug with all Google Fonts I tested, as well as both ways of importing the font. This just punts back to a nice looking font for many platforms.